### PR TITLE
Selenium4.0へのアップデート対応

### DIFF
--- a/Project/Selenium.StandardControls/Selenium.StandardControls.csproj
+++ b/Project/Selenium.StandardControls/Selenium.StandardControls.csproj
@@ -13,10 +13,10 @@
     <Company>Codeer</Company>
     <Copyright></Copyright>
     <Product>Selenium.StandardControls</Product>
-    <Version>0.50.0</Version>
+    <Version>0.51.0</Version>
     <PackageId>Selenium.StandardControls</PackageId>
-    <AssemblyVersion>0.50.0.0</AssemblyVersion>
-    <FileVersion>0.50.0.0</FileVersion>
+    <AssemblyVersion>0.51.0.0</AssemblyVersion>
+    <FileVersion>0.51.0.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/Codeer-Software/Selenium.StandardControls</PackageProjectUrl>
   </PropertyGroup>
@@ -47,7 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Selenium.Support" Version="3.141.0" />
+    <PackageReference Include="Selenium.Support" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/Project/Test/Test.csproj
+++ b/Project/Test/Test.csproj
@@ -43,11 +43,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=3.141.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Selenium.StandardControls\packages\Selenium.WebDriver.3.141.0\lib\net45\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Selenium.StandardControls\packages\Selenium.WebDriver.4.0.1\lib\net46\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.141.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Selenium.StandardControls\packages\Selenium.Support.3.141.0\lib\net45\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Selenium.StandardControls\packages\Selenium.Support.4.0.1\lib\net46\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -102,12 +102,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets')" />
+  <Import Project="..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.95.0.4638.1700\build\Selenium.WebDriver.ChromeDriver.targets" Condition="Exists('..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.95.0.4638.1700\build\Selenium.WebDriver.ChromeDriver.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.90.0.4430.2400\build\Selenium.WebDriver.ChromeDriver.targets'))" />
+    <Error Condition="!Exists('..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.95.0.4638.1700\build\Selenium.WebDriver.ChromeDriver.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\Selenium.StandardControls\packages\Selenium.WebDriver.ChromeDriver.95.0.4638.1700\build\Selenium.WebDriver.ChromeDriver.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Project/Test/packages.config
+++ b/Project/Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ChainingAssertion.Bin" version="1.8.1.3" targetFramework="net46" />
-  <package id="Selenium.Support" version="3.141.0" targetFramework="net46" />
-  <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net46" />
-  <package id="Selenium.WebDriver.ChromeDriver" version="90.0.4430.2400" targetFramework="net46" />
+  <package id="Selenium.Support" version="4.0.1" targetFramework="net46" />
+  <package id="Selenium.WebDriver" version="4.0.1" targetFramework="net46" />
+  <package id="Selenium.WebDriver.ChromeDriver" version="95.0.4638.1700" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
コードの変更はありません。
・System.CodeDomが4.7.0から5.0.0へ更新されていましたが、.NET Framework4.5の環境には入れれないようなので更新していません。
・ChainingAssertion.Binが1.8.1.3から2.0.0へ更新されていましたが、適用するとChainingAssertion.MSTestというアセンブリが読み込めなくなる現象が発生。解決が困難かつテスト用のみということで、更新していません。